### PR TITLE
fix: Adjust subtask inclusion and bulk actions rendering

### DIFF
--- a/src/features/tasks/tasks.slice.ts
+++ b/src/features/tasks/tasks.slice.ts
@@ -140,7 +140,7 @@ export const fetchTaskGroups = createAsyncThunk(
         statuses: '',
         members: selectedMembers,
         projects: '',
-        isSubtasksInclude: true,
+        isSubtasksInclude: false,
         labels: taskReducer.labels.join(' '),
         priorities: taskReducer.priorities.join(' '),
       };

--- a/src/pages/projects/projectView/taskList/groupTables/task-group-wrapper/task-group-wrapper.tsx
+++ b/src/pages/projects/projectView/taskList/groupTables/task-group-wrapper/task-group-wrapper.tsx
@@ -126,10 +126,9 @@ const TaskGroupWrapper = ({ taskGroups, groupBy }: TaskGroupWrapperProps) => {
           />
         ))}
 
-        {/* {selectedTaskIdsList.length > 0 && <TaskListBulkActionsBar />} */}
 
-        {/* bulk action container ==> used tailwind to recreate the animation */}
         {createPortal(<TaskListBulkActionsBar />, document.body, 'bulk-action-container')}
+        
         {createPortal(
           <TaskTemplateDrawer showDrawer={false} selectedTemplateId={''} onClose={() => {}} />,
           document.body,


### PR DESCRIPTION
- Disabled subtask inclusion in task groups fetch request
- Simplified task group wrapper by removing commented code
- Utilized createPortal for consistent bulk actions bar rendering