### PR TITLE
refactor: Rename AssigneeSelector and update import paths

### DIFF
--- a/src/components/board/custom-avatar-group.tsx
+++ b/src/components/board/custom-avatar-group.tsx
@@ -2,7 +2,7 @@ import { Button, Flex } from 'antd';
 import AddMembersDropdown from '@/components/add-members-dropdown/add-members-dropdown';
 import Avatars from '../avatars/avatars';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
-import AssigneeSelector from '../taskListCommon/assigneeSelector/AssigneeSelector';
+import AssigneeSelector from '../taskListCommon/assignee-selector/assignee-selector';
 
 type CustomAvatarGroupProps = {
   task: IProjectTask;

--- a/src/components/task-drawer/shared/infoTab/TaskDetailsForm.tsx
+++ b/src/components/task-drawer/shared/infoTab/TaskDetailsForm.tsx
@@ -20,7 +20,7 @@ import NotifyMemberSelector from './NotifyMemberSelector';
 import TaskDrawerPhaseSelector from './details/task-drawer-phase-selector/task-drawer-phase-selector';
 import TaskDrawerKey from './details/task-drawer-key/task-drawer-key';
 import TaskDrawerLabels from './details/task-drawer-labels/task-drawer-labels';
-import AssigneeSelector from '@/components/taskListCommon/assigneeSelector/AssigneeSelector';
+import AssigneeSelector from '@/components/taskListCommon/assignee-selector/assignee-selector';
 import Avatars from '@/components/avatars/avatars';
 import TaskDrawerDueDate from './details/task-drawer-due-date/task-drawer-due-date';
 

--- a/src/components/taskListCommon/assignee-selector/assignee-selector.tsx
+++ b/src/components/taskListCommon/assignee-selector/assignee-selector.tsx
@@ -26,7 +26,7 @@ import { useAuthService } from '@/hooks/useAuth';
 import { useSocket } from '@/socket/socketContext';
 import { SocketEvents } from '@/shared/socket-events';
 import { ITaskAssigneesUpdateResponse } from '@/types/tasks/task-assignee-update-response';
-import { updateTaskAssignees } from '@/features/tasks/tasks.slice';
+import { fetchTaskAssignees, updateTaskAssignees } from '@/features/tasks/tasks.slice';
 
 interface AssigneeSelectorProps {
   task: IProjectTask;
@@ -48,6 +48,7 @@ const AssigneeSelector = ({ task, groupId = null }: AssigneeSelectorProps) => {
   const dispatch = useAppDispatch();
 
   const members = useAppSelector(state => state.teamMembersReducer.teamMembers);
+  const {loadingAssignees} = useAppSelector(state => state.taskReducer);
 
   const filteredMembersData = useMemo(() => {
     return teamMembers?.data?.filter(member =>
@@ -96,10 +97,6 @@ const AssigneeSelector = ({ task, groupId = null }: AssigneeSelectorProps) => {
     socket?.emit(SocketEvents.QUICK_ASSIGNEES_UPDATE.toString(), JSON.stringify(body));
   };
 
-  const handleAssignMembers = () => {
-    console.log(teamMembers.data);
-  };
-
   const handleQuickAssigneesUpdate = (data: ITaskAssigneesUpdateResponse) => {
     const updatedAssignees = data.assignees.map(assignee => ({
       ...assignee,
@@ -108,15 +105,14 @@ const AssigneeSelector = ({ task, groupId = null }: AssigneeSelectorProps) => {
     dispatch(
       updateTaskAssignees({ groupId: groupId || '', taskId: data.id, assignees: updatedAssignees })
     );
-    
   };
 
   useEffect(() => {
     socket?.on(
       SocketEvents.QUICK_ASSIGNEES_UPDATE.toString(),
       (data: ITaskAssigneesUpdateResponse) => {
-        console.log(data);
         if (data) handleQuickAssigneesUpdate(data);
+        if (projectId && !loadingAssignees) dispatch(fetchTaskAssignees(projectId));
       }
     );
     return () => {
@@ -205,16 +201,16 @@ const AssigneeSelector = ({ task, groupId = null }: AssigneeSelectorProps) => {
           {t('assigneeSelectorInviteButton')}
         </Button>
 
-        <Divider style={{ marginBlock: 8 }} />
+        {/* <Divider style={{ marginBlock: 8 }} /> */}
 
-        <Button
+        {/* <Button
           type="primary"
           style={{ alignSelf: 'flex-end' }}
           size="small"
           onClick={handleAssignMembers}
         >
           {t('okButton')}
-        </Button>
+        </Button> */}
       </Flex>
     </Card>
   );

--- a/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
+++ b/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
@@ -19,12 +19,9 @@ const ProjectViewTaskList = () => {
     taskGroups,
     loadingGroups,
     group: groupBy,
-    archived,
     labels,
     fields,
     search,
-    priorities,
-    taskAssignees,
   } = useAppSelector(state => state.taskReducer);
   const { statusCategories, loading: loadingStatusCategories } = useAppSelector(state => state.taskStatusReducer);
   const { loadingPhases } = useAppSelector(state => state.phaseReducer);
@@ -39,7 +36,7 @@ const ProjectViewTaskList = () => {
     if (!statusCategories.length) {
       dispatch(fetchStatusesCategories());
     }
-  }, [dispatch, projectId, archived, groupBy, labels, fields, search, priorities, taskAssignees]);
+  }, [dispatch, projectId, groupBy, fields, search]);
 
   return (
     <Flex vertical gap={16} style={{ overflowX: 'hidden' }}>

--- a/src/pages/projects/projectView/taskList/taskListFilters/LabelsFilterDropdown.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/LabelsFilterDropdown.tsx
@@ -15,7 +15,7 @@ import { useAppSelector } from '@/hooks/useAppSelector';
 import { colors } from '@/styles/colors';
 import { useTranslation } from 'react-i18next';
 import { ITaskLabel } from '@/types/tasks/taskLabel.types';
-import { setLabels } from '@/features/tasks/tasks.slice';
+import { fetchTaskGroups, setLabels } from '@/features/tasks/tasks.slice';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
 
 interface LabelsFilterDropdownProps {
@@ -28,7 +28,7 @@ const LabelsFilterDropdown = (props: LabelsFilterDropdownProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
 
   const { labels } = useAppSelector(state => state.taskReducer);
-
+  const { projectId } = useAppSelector(state => state.projectReducer);
   const { t } = useTranslation('task-list-filters');
 
   const filteredLabelData = useMemo(() => {
@@ -49,6 +49,7 @@ const LabelsFilterDropdown = (props: LabelsFilterDropdownProps) => {
       newLabels.splice(newLabels.indexOf(labelId), 1);
       dispatch(setLabels(newLabels));
     }
+    if (projectId) dispatch(fetchTaskGroups(projectId));
   };
 
   // function to focus labels input

--- a/src/pages/projects/projectView/taskList/taskListFilters/MembersFilterDropdown.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/MembersFilterDropdown.tsx
@@ -17,7 +17,7 @@ import { useAppSelector } from '@/hooks/useAppSelector';
 import { colors } from '@/styles/colors';
 import SingleAvatar from '@components/common/single-avatar/single-avatar';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
-import { setMembers } from '@/features/tasks/tasks.slice';
+import { fetchTaskGroups, setMembers } from '@/features/tasks/tasks.slice';
 
 const MembersFilterDropdown = () => {
   const membersInputRef = useRef<InputRef>(null);
@@ -28,7 +28,7 @@ const MembersFilterDropdown = () => {
 
   const themeMode = useAppSelector(state => state.themeReducer.mode);
   const { taskAssignees } = useAppSelector(state => state.taskReducer);
-
+  const { projectId } = useAppSelector(state => state.projectReducer);
   const [searchQuery, setSearchQuery] = useState<string>('');
 
   const filteredMembersData = useMemo(() => {
@@ -37,13 +37,14 @@ const MembersFilterDropdown = () => {
     );
   }, [taskAssignees, searchQuery]);
 
-  const handleSelectedFiltersCount = (memberId: string | undefined, checked: boolean) => {
+  const handleSelectedFiltersCount = async (memberId: string | undefined, checked: boolean) => {
     setSelectedCount(checked ? selectedCount + 1 : selectedCount - 1);
     if (!memberId) return;
     const newTaskAssignees = taskAssignees.map(member =>
       member.id === memberId ? { ...member, selected: checked } : member
     );
-    dispatch(setMembers(newTaskAssignees));
+    await dispatch(setMembers(newTaskAssignees));
+    if (projectId) dispatch(fetchTaskGroups(projectId));
   };
 
   const membersDropdownContent = (

--- a/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '@/hooks/useAppSelector';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
 import { fetchTaskAssignees, toggleArchived } from '@/features/tasks/tasks.slice';
 import { getTeamMembers } from '@/features/team-members/team-members.slice';
+import { fetchTaskGroups } from '@/features/board/board-slice';
 
 const SearchDropdown = React.lazy(() => import('./SearchDropdown'));
 const SortFilterDropdown = React.lazy(() => import('./SortFilterDropdown'));
@@ -37,6 +38,7 @@ const TaskListFilters: React.FC<TaskListFiltersProps> = ({ position }) => {
 
   const handleShowArchivedChange = () => {
     dispatch(toggleArchived());
+    if (projectId) dispatch(fetchTaskGroups(projectId));
   };
 
   useEffect(() => {

--- a/src/pages/projects/projectView/taskList/taskListTable/TaskListTable.tsx
+++ b/src/pages/projects/projectView/taskList/taskListTable/TaskListTable.tsx
@@ -41,7 +41,7 @@ import TaskListLastUpdatedCell from './task-list-table-cells/task-list-last-upda
 import TaskListReporterCell from './task-list-table-cells/task-list-reporter-cell/task-list-reporter-cell';
 import TaskListDueTimeCell from './task-list-table-cells/task-list-due-time-cell/task-list-due-time-cell';
 import PhaseDropdown from '@/components/taskListCommon/phaseDropdown/PhaseDropdown';
-import AssigneeSelector from '@/components/taskListCommon/assigneeSelector/AssigneeSelector';
+import AssigneeSelector from '@/components/taskListCommon/assignee-selector/assignee-selector';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
 import { CustomFieldsTypes } from '@/features/projects/singleProject/task-list-custom-columns/task-list-custom-columns-slice';
 import {

--- a/src/pages/projects/projectView/taskList/taskListTable/task-list-table-cells/task-list-members-cell/task-list-members-cell.tsx
+++ b/src/pages/projects/projectView/taskList/taskListTable/task-list-table-cells/task-list-members-cell/task-list-members-cell.tsx
@@ -1,8 +1,7 @@
 import Flex from 'antd/es/flex';
 
 import Avatars from '@/components/avatars/avatars';
-import AssigneeSelector from '@/components/taskListCommon/assigneeSelector/AssigneeSelector';
-import { useState } from 'react';
+import AssigneeSelector from '@/components/taskListCommon/assignee-selector/assignee-selector';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
 
 type TaskListMembersCellProps = {
@@ -11,12 +10,10 @@ type TaskListMembersCellProps = {
 };
 
 const TaskListMembersCell = ({ groupId, task }: TaskListMembersCellProps) => {
-  const [showDropdown, setShowDropdown] = useState(false);
-
   return (
     <Flex gap={4} align="center" onClick={() => {}}>
       <Avatars members={task.assignees || []} />
-      <AssigneeSelector showDropdown={showDropdown} task={task} groupId={groupId} />
+      <AssigneeSelector task={task} groupId={groupId} />
     </Flex>
   );
 };


### PR DESCRIPTION
- Renamed AssigneeSelector component to follow kebab-case naming convention
- Updated import paths across multiple components
- Removed unused props and simplified component imports
- Triggered task groups refresh on filter changes