### PR TITLE
feat: Initialize label selection state when setting labels

### DIFF
--- a/src/features/tasks/tasks.slice.ts
+++ b/src/features/tasks/tasks.slice.ts
@@ -306,7 +306,8 @@ const taskSlice = createSlice({
     },
 
     setLabels: (state, action: PayloadAction<ITaskLabel[]>) => {
-      state.labels = action.payload;
+      const newLabels = action.payload.map(label => ({...label, selected: false}));
+      state.labels = newLabels;
     },
 
     setMembers: (state, action: PayloadAction<ITaskListMemberFilter[]>) => {


### PR DESCRIPTION
- Add 'selected' property to labels when setting them in the tasks slice
- Ensure new labels are initialized with a default unselected state