### PR TITLE
refactor: Centralize label socket event handling and update label sta…

### DIFF
--- a/src/components/taskListCommon/labelsSelector/LabelsSelector.tsx
+++ b/src/components/taskListCommon/labelsSelector/LabelsSelector.tsx
@@ -33,7 +33,7 @@ interface LabelsSelectorProps {
 
 const LabelsSelector = ({ task }: LabelsSelectorProps) => {
   const { t } = useTranslation('task-list-table');
-  const { socket, connected } = useSocket();
+  const { socket } = useSocket();
   const dispatch = useAppDispatch();
 
   const labelInputRef = useRef<InputRef>(null);
@@ -45,13 +45,6 @@ const LabelsSelector = ({ task }: LabelsSelectorProps) => {
 
   const currentSession = useAuthService().getCurrentSession();
   const themeMode = useAppSelector(state => state.themeReducer.mode);
-
-  const handleLabelsChange = async (labels: ILabelsChangeResponse) => {
-    await dispatch(updateTaskLabel(labels));
-    await dispatch(fetchLabels());
-    if (projectId) await dispatch(fetchLabelsByProject(projectId));
-    setSearchQuery('');
-  };
 
   const handleLabelChange = (label: ITaskLabel) => {
     const labelData = {
@@ -78,18 +71,6 @@ const LabelsSelector = ({ task }: LabelsSelectorProps) => {
   useEffect(() => {
     setLabelList(labels as ITaskLabel[]);
   }, [labels, task.labels]);
-
-  useEffect(() => {
-    if (connected) {
-      socket?.on(SocketEvents.TASK_LABELS_CHANGE.toString(), handleLabelsChange);
-      socket?.on(SocketEvents.CREATE_LABEL.toString(), handleLabelsChange);
-    }
-
-    return () => {
-      socket?.removeListener(SocketEvents.TASK_LABELS_CHANGE.toString(), handleLabelsChange);
-      socket?.removeListener(SocketEvents.CREATE_LABEL.toString(), handleLabelsChange);
-    };
-  }, [connected]);
 
   // used useMemo hook for re render the list when searching
   const filteredLabelData = useMemo(() => {

--- a/src/features/tasks/tasks.slice.ts
+++ b/src/features/tasks/tasks.slice.ts
@@ -17,7 +17,7 @@ import { ITaskStatusViewModel } from '@/types/tasks/taskStatusGetResponse.types'
 import { ITaskListStatusChangeResponse } from '@/types/tasks/task-list-status.types';
 import { ITaskListPriorityChangeResponse } from '@/types/tasks/task-list-priority.types';
 import { labelsApiService } from '@/api/taskAttributes/labels/labels.api.service';
-import { ITaskLabel } from '@/types/tasks/taskLabel.types';
+import { ITaskLabel, ITaskLabelFilter } from '@/types/tasks/taskLabel.types';
 
 export enum IGroupBy {
   STATUS = 'status',
@@ -71,7 +71,7 @@ interface ITaskState {
   statuses: ITaskStatusViewModel[];
 
   loadingLabels: boolean;
-  labels: ITaskLabel[];
+  labels: ITaskLabelFilter[];
   priorities: string[];
   members: string[];
   activeTimers: { [taskId: string]: number | null };
@@ -140,7 +140,7 @@ export const fetchTaskGroups = createAsyncThunk(
       const selectedLabels = taskReducer.labels
         .filter(label => label.selected)
         .map(label => label.id)
-        .join(' ');
+        .join(' ');        
 
       const config: ITaskListConfigV2 = {
         id: projectId,
@@ -306,8 +306,7 @@ const taskSlice = createSlice({
     },
 
     setLabels: (state, action: PayloadAction<ITaskLabel[]>) => {
-      const newLabels = action.payload.map(label => ({...label, selected: false}));
-      state.labels = newLabels;
+      state.labels = action.payload;
     },
 
     setMembers: (state, action: PayloadAction<ITaskListMemberFilter[]>) => {
@@ -680,8 +679,9 @@ const taskSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchLabelsByProject.fulfilled, (state, action: PayloadAction<ITaskLabel[]>) => {
+        const newLabels = action.payload.map(label => ({...label, selected: false}));
+        state.labels = newLabels;
         state.loadingLabels = false;
-        state.labels = action.payload;
       })
       .addCase(fetchLabelsByProject.rejected, (state, action) => {
         state.loadingLabels = false;

--- a/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
+++ b/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
@@ -6,10 +6,9 @@ import TaskListFilters from './taskListFilters/TaskListFilters';
 import TaskGroupWrapper from './groupTables/task-group-wrapper/task-group-wrapper';
 import { useAppSelector } from '@/hooks/useAppSelector';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
-import { fetchTaskGroups, fetTaskListColumns, fetchTaskAssignees, updateTaskAssignees } from '@/features/tasks/tasks.slice';
+import { fetchTaskGroups, fetTaskListColumns } from '@/features/tasks/tasks.slice';
 import { fetchStatusesCategories } from '@/features/taskAttributes/taskStatusSlice';
 import { fetchPhasesByProjectId } from '@/features/projects/singleProject/phase/phases.slice';
-import { setProjectView } from '@/features/project/project.slice';
 
 const ProjectViewTaskList = () => {
   const dispatch = useAppDispatch();
@@ -19,7 +18,7 @@ const ProjectViewTaskList = () => {
     taskGroups,
     loadingGroups,
     group: groupBy,
-    labels,
+    archived,
     fields,
     search,
   } = useAppSelector(state => state.taskReducer);
@@ -36,7 +35,7 @@ const ProjectViewTaskList = () => {
     if (!statusCategories.length) {
       dispatch(fetchStatusesCategories());
     }
-  }, [dispatch, projectId, groupBy, fields, search]);
+  }, [dispatch, projectId, groupBy, fields, search, archived]);
 
   return (
     <Flex vertical gap={16} style={{ overflowX: 'hidden' }}>

--- a/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
@@ -40,7 +40,6 @@ const TaskListFilters: React.FC<TaskListFiltersProps> = ({ position }) => {
 
   const handleShowArchivedChange = () => {
     dispatch(toggleArchived());
-    if (projectId) dispatch(fetchTaskGroups(projectId));
   };
 
   useEffect(() => {


### PR DESCRIPTION
…te management

- Move label socket event listeners from LabelsSelector to TaskGroupWrapper
- Simplify label state initialization in tasks slice
- Update label filtering and selection logic
- Remove redundant socket connection checks