### PR TITLE
feat: Implement inline phase name editing with dynamic updates

### DIFF
--- a/src/api/taskAttributes/phases/phases.api.service.ts
+++ b/src/api/taskAttributes/phases/phases.api.service.ts
@@ -35,7 +35,7 @@ export const phasesApiService = {
   },
 
   updatePhaseColor: async (projectId: string, body: ITaskPhase) => {
-    const q = toQueryString({id: projectId, current_project_id: projectId})
+    const q = toQueryString({ id: projectId, current_project_id: projectId });
     const response = await apiClient.put<IServerResponse<ITaskPhase>>(
       `${rootUrl}/change-color/${body.id}${q}`,
       body
@@ -43,10 +43,12 @@ export const phasesApiService = {
     return response.data;
   },
 
-  updatePhaseName: async (projectId: string, name: string,) => {
-    const q = toQueryString({current_project_id: projectId})
+  updateNameOfPhase: async (phaseId: string, body: ITaskPhase, projectId: string,) => {
+    const q = toQueryString({ id: projectId, current_project_id: projectId });
     const response = await apiClient.put<IServerResponse<ITaskPhase>>(
-      `${rootUrl}/label/${projectId}${q}`, {name});
+      `${rootUrl}/${phaseId}${q}`,
+      body
+    );
     return response.data;
   },
 
@@ -62,7 +64,9 @@ export const phasesApiService = {
   updateProjectPhaseLabel: async (projectId: string, phaseLabel: string) => {
     const q = toQueryString({ id: projectId, current_project_id: projectId });
     const response = await apiClient.put<IServerResponse<ITaskPhase>>(
-      `${rootUrl}/label/${projectId}${q}`, {name: phaseLabel});
+      `${rootUrl}/label/${projectId}${q}`,
+      { name: phaseLabel }
+    );
     return response.data;
   },
 };

--- a/src/features/projects/singleProject/phase/phases.slice.ts
+++ b/src/features/projects/singleProject/phase/phases.slice.ts
@@ -94,7 +94,17 @@ export const updateProjectPhaseLabel = createAsyncThunk(
   }
 );
 
-
+export const updatePhaseName = createAsyncThunk(
+  'phase/updatePhaseName',
+  async ({ phaseId, phase, projectId }: { phaseId: string; phase: ITaskPhase; projectId: string }, { rejectWithValue }) => {
+    try {
+      const response = await phasesApiService.updateNameOfPhase(phaseId, phase, projectId);
+      return response;
+    } catch (error) {
+      return rejectWithValue(error);
+    }
+  }
+);
 const phaseSlice = createSlice({
   name: 'phaseReducer',
   initialState,


### PR DESCRIPTION
- Update phasesApiService with new updateNameOfPhase method
- Add updatePhaseName thunk in phases slice for handling phase name changes
- Enhance PhaseOptionItem with local state and event handlers for phase name editing
- Trigger task groups refresh after phase name update to maintain UI consistency
- Improve error handling and state management for phase name changes