### PR TITLE
fix: Correct groupBy state preservation in task slice reset

### DIFF
--- a/src/features/tasks/tasks.slice.ts
+++ b/src/features/tasks/tasks.slice.ts
@@ -50,8 +50,8 @@ export const getCurrentGroup = (): IGroupByOption => {
   return GROUP_BY_OPTIONS[0];
 };
 
-export const setCurrentGroup = (group: IGroupBy): void => {
-  localStorage.setItem(LOCALSTORAGE_GROUP_KEY, group);
+export const setCurrentGroup = (groupBy: IGroupBy): void => {
+  localStorage.setItem(LOCALSTORAGE_GROUP_KEY, groupBy);
 };
 
 interface ITaskState {
@@ -723,7 +723,7 @@ const taskSlice = createSlice({
     resetTaskListData: state => {
       return {
         ...initialState,
-        group: state.groupBy, // Preserve the current grouping
+        groupBy: state.groupBy, // Preserve the current grouping
       };
     },
 


### PR DESCRIPTION
- Update parameter naming in setCurrentGroup for clarity
- Fix state reset to correctly preserve groupBy value
- Ensure consistent state management during task list reset