### PR TITLE
refactor: Rename group state and update related components

### DIFF
--- a/src/pages/projects/projectView/board/ProjectViewBoard.tsx
+++ b/src/pages/projects/projectView/board/ProjectViewBoard.tsx
@@ -10,15 +10,17 @@ import BoardViewTaskCard from './board-section/board-task-card/board-view-task-c
 
 const ProjectViewBoard = () => {
   const { projectId } = useAppSelector(state => state.projectReducer);
-  const { taskGroups, group, loadingGroups, error } = useAppSelector(state => state.boardReducer);
+  const { taskGroups, groupBy, loadingGroups, error } = useAppSelector(state => state.boardReducer);
   const dispatch = useAppDispatch();
   const [activeItem, setActiveItem] = useState<any>(null);
 
   useEffect(() => {
-    if (projectId && !loadingGroups) {
-      dispatch(fetchTaskGroups(projectId));
+    if (projectId && groupBy) {
+      if (!loadingGroups) {
+        dispatch(fetchTaskGroups(projectId))
+      }
     }
-  }, [dispatch, projectId]);
+  }, [dispatch, projectId, groupBy]);
 
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;

--- a/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
+++ b/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
@@ -27,8 +27,10 @@ const ProjectViewTaskList = () => {
   const { loadingColumns } = useAppSelector(state => state.taskReducer);
 
   useEffect(() => {
-    if (projectId) {
-      if (!loadingGroups) dispatch(fetchTaskGroups(projectId));
+    if (projectId && groupBy) {
+      if (!loadingGroups) {
+        dispatch(fetchTaskGroups(projectId));
+      }
       if (!loadingColumns) dispatch(fetTaskListColumns(projectId));
       if (!loadingPhases) dispatch(fetchPhasesByProjectId(projectId));
     }


### PR DESCRIPTION
- Rename 'group' to 'groupBy' in board slice for clarity
- Update ProjectViewBoard and ProjectViewTaskList to use new 'groupBy' state
- Remove unused imports and clean up state management
- Improve type consistency and state access in task group fetching