### PR TITLE
fix: Reset task subscribers when closing task drawer

### DIFF
--- a/src/components/task-drawer/task-drawer.tsx
+++ b/src/components/task-drawer/task-drawer.tsx
@@ -10,6 +10,7 @@ import {
   setSelectedTaskId,
   setShowTaskDrawer,
   setTaskFormViewModel,
+  setTaskSubscribers,
 } from '@/features/task-drawer/task-drawer.slice';
 
 import './task-drawer.css';
@@ -38,6 +39,7 @@ const TaskDrawer = () => {
     dispatch(setShowTaskDrawer(false));
     dispatch(setSelectedTaskId(null));
     dispatch(setTaskFormViewModel({}));
+    dispatch(setTaskSubscribers([]));
   };
 
   const tabItems: TabsProps['items'] = [


### PR DESCRIPTION
- Clear task subscribers state when closing the task drawer
- Dispatch setTaskSubscribers with an empty array to ensure clean state
- Maintain consistent state management for task drawer interactions