### PR TITLE
refactor: Unify board and task list filter state management

### DIFF
--- a/src/components/task-templates/import-task-template.tsx
+++ b/src/components/task-templates/import-task-template.tsx
@@ -19,7 +19,7 @@ import { ITaskTemplatesGetResponse } from '@/types/settings/task-templates.types
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
 import { taskTemplatesApiService } from '@/api/task-templates/task-templates.api.service';
 import logger from '@/utils/errorLogger';
-import { fetchTaskGroups } from '@/features/board/board-slice';
+import { fetchBoardTaskGroups } from '@/features/board/board-slice';
 import { setImportTaskTemplateDrawerOpen } from '@/features/project/project.slice';
 
 const ImportTaskTemplate = () => {
@@ -86,7 +86,7 @@ const ImportTaskTemplate = () => {
       setImporting(true);
       const res = await taskTemplatesApiService.importTemplate(projectId, tasks);
       if (res.done) {
-        dispatch(fetchTaskGroups(projectId));
+        dispatch(fetchBoardTaskGroups(projectId));
         dispatch(setImportTaskTemplateDrawerOpen(false));
       }
     } catch (error) {

--- a/src/features/projects/singleProject/phase/PhaseOptionItem.tsx
+++ b/src/features/projects/singleProject/phase/PhaseOptionItem.tsx
@@ -10,7 +10,7 @@ import logger from '@/utils/errorLogger';
 import { useState, useEffect } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { fetchTaskGroups } from '@/features/board/board-slice';
+import { fetchBoardTaskGroups } from '@/features/board/board-slice';
 import { updatePhaseLabel } from '@/features/project/project.slice';
 
 const PhaseOptionItem = ({
@@ -64,7 +64,7 @@ const PhaseOptionItem = ({
         })).unwrap();
         if (response.done) {
           dispatch(fetchPhasesByProjectId(projectId));
-          await dispatch(fetchTaskGroups(projectId));
+          await dispatch(fetchBoardTaskGroups(projectId));
         }
       } catch (error) {
         logger.error('Error updating phase name', error);
@@ -82,7 +82,7 @@ const PhaseOptionItem = ({
       ).unwrap();
       if (response.done) {
         dispatch(fetchPhasesByProjectId(projectId || ''));
-        await dispatch(fetchTaskGroups(projectId || ''));
+        await dispatch(fetchBoardTaskGroups(projectId || ''));
       }
     } catch (error) {
       logger.error('Error deleting phase option', error);
@@ -96,7 +96,7 @@ const PhaseOptionItem = ({
       const response = await dispatch(updatePhaseColor({ projectId, body: phase })).unwrap();
       if (response.done) {
         dispatch(fetchPhasesByProjectId(projectId || ''));
-        await dispatch(fetchTaskGroups(projectId || ''));
+        await dispatch(fetchBoardTaskGroups(projectId || ''));
       }
     } catch (error) {
       logger.error('Error changing phase color', error);

--- a/src/pages/projects/projectView/board/ProjectViewBoard.tsx
+++ b/src/pages/projects/projectView/board/ProjectViewBoard.tsx
@@ -3,7 +3,7 @@ import { useAppSelector } from '@/hooks/useAppSelector';
 import TaskListFilters from '../taskList/taskListFilters/TaskListFilters';
 import { Empty, Flex, Skeleton } from 'antd';
 import BoardSectionCardContainer from './board-section/board-section-container';
-import { fetchTaskGroups, reorderTaskGroups } from '@features/board/board-slice';
+import { fetchBoardTaskGroups, reorderTaskGroups } from '@features/board/board-slice';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
 import {
   DndContext,
@@ -14,17 +14,21 @@ import {
   DragOverlay,
 } from '@dnd-kit/core';
 import BoardViewTaskCard from './board-section/board-task-card/board-view-task-card';
+import { useSearchParams } from 'react-router-dom';
 
 const ProjectViewBoard = () => {
-  const { projectId, projectView } = useAppSelector(state => state.projectReducer);
+  const { projectId } = useAppSelector(state => state.projectReducer);
   const { taskGroups, groupBy, loadingGroups, error } = useAppSelector(state => state.boardReducer);
   const dispatch = useAppDispatch();
   const [activeItem, setActiveItem] = useState<any>(null);
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get('tab');
+  const projectView = tab === 'list' ? 'list' : 'kanban';
 
   useEffect(() => {
     if (projectId && groupBy && projectView === 'kanban') {
       if (!loadingGroups) {
-        dispatch(fetchTaskGroups(projectId));
+        dispatch(fetchBoardTaskGroups(projectId));
       }
     }
   }, [dispatch, projectId, groupBy, projectView]);

--- a/src/pages/projects/projectView/board/board-section/board-section-card/board-section-card.tsx
+++ b/src/pages/projects/projectView/board/board-section/board-section-card/board-section-card.tsx
@@ -20,7 +20,7 @@ import { taskListBulkActionsApiService } from '@/api/tasks/task-list-bulk-action
 import { useSocket } from '@/socket/socketContext';
 import { SocketEvents } from '@/shared/socket-events';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
-import { fetchTaskGroups } from '@/features/board/board-slice';
+import { fetchBoardTaskGroups } from '@/features/board/board-slice';
 import logger from '@/utils/errorLogger';
 
 interface IBoardSectionCardProps {
@@ -100,7 +100,7 @@ const BoardSectionCard = ({ taskGroup }: IBoardSectionCardProps) => {
     socket?.once(SocketEvents.QUICK_TASK.toString(), (task: IProjectTask) => {
       setCreatingTempTask(false);
       if (task && task.id) {
-        dispatch(fetchTaskGroups(projectId));
+        dispatch(fetchBoardTaskGroups(projectId));
       }
     });
   };

--- a/src/pages/projects/projectView/board/board-section/board-task-card/board-view-task-card.tsx
+++ b/src/pages/projects/projectView/board/board-section/board-task-card/board-view-task-card.tsx
@@ -37,7 +37,7 @@ import BoardSubTaskCard from '../board-sub-task-card/board-sub-task-card';
 import CustomAvatarGroup from '@/components/board/custom-avatar-group';
 import CustomDueDatePicker from '@/components/board/custom-due-date-picker';
 import { colors } from '@/styles/colors';
-import { deleteBoardTask, updateTaskAssignee } from '@features/board/board-slice';
+import { deleteBoardTask, updateBoardTaskAssignee } from '@features/board/board-slice';
 import BoardCreateSubtaskCard from '../board-sub-task-card/board-create-sub-task-card';
 import { setShowTaskDrawer, setSelectedTaskId } from '@/features/task-drawer/task-drawer.slice';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
@@ -81,7 +81,7 @@ const BoardViewTaskCard = ({ task, sectionId }: { task: IProjectTask; sectionId:
       if (res.done) {
         trackMixpanelEvent(evt_project_task_list_context_menu_assign_me);
         dispatch(
-          updateTaskAssignee({
+          updateBoardTaskAssignee({
             body: res.body,
             sectionId,
             taskId: task.id,

--- a/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
+++ b/src/pages/projects/projectView/taskList/ProjectViewTaskList.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import Flex from 'antd/es/flex';
 import Skeleton from 'antd/es/skeleton';
+import { useSearchParams } from 'react-router-dom';
 
 import TaskListFilters from './taskListFilters/TaskListFilters';
 import TaskGroupWrapper from './groupTables/task-group-wrapper/task-group-wrapper';
@@ -12,8 +13,11 @@ import { fetchPhasesByProjectId } from '@/features/projects/singleProject/phase/
 
 const ProjectViewTaskList = () => {
   const dispatch = useAppDispatch();
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get('tab');
+  const projectView = tab === 'tasks-list' ? 'list' : 'kanban';
 
-  const { projectId, projectView } = useAppSelector(state => state.projectReducer);
+  const { projectId } = useAppSelector(state => state.projectReducer);
   const { taskGroups, loadingGroups, groupBy, archived, fields, search } = useAppSelector(
     state => state.taskReducer
   );

--- a/src/pages/projects/projectView/taskList/taskListFilters/MembersFilterDropdown.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/MembersFilterDropdown.tsx
@@ -1,51 +1,107 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CaretDownFilled } from '@ant-design/icons';
-import Badge from 'antd/es/badge';
-import Button from 'antd/es/button';
-import Card from 'antd/es/card';
-import Checkbox from 'antd/es/checkbox';
-import Dropdown from 'antd/es/dropdown';
-import Empty from 'antd/es/empty';
-import Flex from 'antd/es/flex';
-import Input, { InputRef } from 'antd/es/input';
-import List from 'antd/es/list';
-import Space from 'antd/es/space';
-import Typography from 'antd/es/typography';
+import { 
+  Badge, 
+  Button, 
+  Card, 
+  Checkbox, 
+  Dropdown, 
+  Empty, 
+  Flex, 
+  Input, 
+  List, 
+  Space, 
+  Typography 
+} from 'antd';
+import type { InputRef } from 'antd';
+import { useSearchParams } from 'react-router-dom';
 
+import { useAppDispatch } from '@/hooks/useAppDispatch';
 import { useAppSelector } from '@/hooks/useAppSelector';
+
 import { colors } from '@/styles/colors';
 import SingleAvatar from '@components/common/single-avatar/single-avatar';
-import { useAppDispatch } from '@/hooks/useAppDispatch';
 import { fetchTaskGroups, setMembers } from '@/features/tasks/tasks.slice';
+import { fetchBoardTaskGroups, setBoardMembers } from '@/features/board/board-slice';
+
+interface Member {
+  id: string;
+  name?: string;
+  email?: string;
+  avatar_url?: string;
+  selected: boolean;
+}
 
 const MembersFilterDropdown = () => {
   const membersInputRef = useRef<InputRef>(null);
   const dispatch = useAppDispatch();
-  const [selectedCount, setSelectedCount] = useState<number>(0);
-
+  const [searchParams] = useSearchParams();
+  const [selectedCount, setSelectedCount] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
   const { t } = useTranslation('task-list-filters');
 
   const themeMode = useAppSelector(state => state.themeReducer.mode);
   const { taskAssignees } = useAppSelector(state => state.taskReducer);
+  const { taskAssignees: boardTaskAssignees } = useAppSelector(state => state.boardReducer);
   const { projectId } = useAppSelector(state => state.projectReducer);
-  const [searchQuery, setSearchQuery] = useState<string>('');
+
+  const tab = searchParams.get('tab');
+  const projectView = tab === 'list' ? 'list' : 'kanban';
 
   const filteredMembersData = useMemo(() => {
-    return taskAssignees.filter(member =>
+    const members = projectView === 'list' ? taskAssignees : boardTaskAssignees;
+    return members.filter(member => 
       member.name?.toLowerCase().includes(searchQuery.toLowerCase())
     );
-  }, [taskAssignees, searchQuery]);
+  }, [taskAssignees, boardTaskAssignees, searchQuery, projectView]);
 
-  const handleSelectedFiltersCount = async (memberId: string | undefined, checked: boolean) => {
-    setSelectedCount(checked ? selectedCount + 1 : selectedCount - 1);
-    if (!memberId) return;
-    const newTaskAssignees = taskAssignees.map(member =>
-      member.id === memberId ? { ...member, selected: checked } : member
-    );
-    await dispatch(setMembers(newTaskAssignees));
-    if (projectId) dispatch(fetchTaskGroups(projectId));
-  };
+  const handleSelectedFiltersCount = useCallback(async (memberId: string | undefined, checked: boolean) => {
+    setSelectedCount(prev => checked ? prev + 1 : prev - 1);
+    
+    if (!memberId || !projectId) return;
+
+    const updateMembers = async (members: Member[], setAction: any, fetchAction: any) => {
+      const updatedMembers = members.map(member => 
+        member.id === memberId ? { ...member, selected: checked } : member
+      );
+      await dispatch(setAction(updatedMembers));
+      dispatch(fetchAction(projectId));
+    };
+    if (projectView === 'list') {
+      await updateMembers(taskAssignees as Member[], setMembers, fetchTaskGroups);
+    } else {
+      await updateMembers(boardTaskAssignees as Member[], setBoardMembers, fetchBoardTaskGroups);
+    }
+  }, [projectId, projectView, taskAssignees, boardTaskAssignees, dispatch]);
+
+  const renderMemberItem = (member: Member) => (
+    <List.Item
+      className={`custom-list-item ${themeMode === 'dark' ? 'dark' : ''}`}
+      key={member.id}
+      style={{ display: 'flex', gap: 8, padding: '4px 8px', border: 'none' }}
+    >
+      <Checkbox
+        id={member.id}
+        checked={member.selected}
+        onChange={e => handleSelectedFiltersCount(member.id, e.target.checked)}
+      >
+        <div style={{ display: 'flex', gap: 8 }}>
+          <SingleAvatar
+            avatarUrl={member.avatar_url}
+            name={member.name}
+            email={member.email}
+          />
+          <Flex vertical>
+            {member.name}
+            <Typography.Text style={{ fontSize: 12, color: colors.lightGray }}>
+              {member.email}
+            </Typography.Text>
+          </Flex>
+        </div>
+      </Checkbox>
+    </List.Item>
+  );
 
   const membersDropdownContent = (
     <Card className="custom-card" styles={{ body: { padding: 8 } }}>
@@ -53,67 +109,33 @@ const MembersFilterDropdown = () => {
         <Input
           ref={membersInputRef}
           value={searchQuery}
-          onChange={e => setSearchQuery(e.currentTarget.value)}
+          onChange={e => setSearchQuery(e.target.value)}
           placeholder={t('searchInputPlaceholder')}
         />
-
         <List style={{ padding: 0, maxHeight: 250, overflow: 'auto' }}>
-          {filteredMembersData.length ? (
-            filteredMembersData.map(member => (
-              <List.Item
-                className={`custom-list-item ${themeMode === 'dark' ? 'dark' : ''}`}
-                key={member.id}
-                style={{
-                  display: 'flex',
-                  gap: 8,
-                  padding: '4px 8px',
-                  border: 'none',
-                }}
-              >
-                <Checkbox
-                  id={member.id}
-                  checked={member.selected}
-                  onChange={e => handleSelectedFiltersCount(member.id, e.target.checked)}
-                >
-                  <div style={{ display: 'flex', gap: 8 }}>
-                    <div>
-                      <SingleAvatar
-                        avatarUrl={member.avatar_url}
-                        name={member.name}
-                        email={member.email}
-                      />
-                    </div>
-                    <Flex vertical>
-                      {member.name}
-
-                      <Typography.Text
-                        style={{
-                          fontSize: 12,
-                          color: colors.lightGray,
-                        }}
-                      >
-                        {member.email}
-                      </Typography.Text>
-                    </Flex>
-                  </div>
-                </Checkbox>
-              </List.Item>
-            ))
-          ) : (
+          {filteredMembersData.length ? 
+            filteredMembersData.map((member, index) => renderMemberItem(member as Member)) : 
             <Empty />
-          )}
+          }
         </List>
       </Flex>
     </Card>
   );
 
-  // function to focus members input
-  const handleMembersDropdownOpen = (open: boolean) => {
+  const handleMembersDropdownOpen = useCallback((open: boolean) => {
     if (open) {
-      setTimeout(() => {
-        membersInputRef.current?.focus();
-      }, 0);
+      setTimeout(() => membersInputRef.current?.focus(), 0);
+      if (taskAssignees.length) {
+        dispatch(setBoardMembers(taskAssignees));
+      }
     }
+  }, [dispatch, taskAssignees]);
+
+  const buttonStyle = {
+    backgroundColor: selectedCount > 0
+      ? themeMode === 'dark' ? '#003a5c' : colors.paleBlue
+      : colors.transparent,
+    color: selectedCount > 0 ? (themeMode === 'dark' ? 'white' : colors.darkGray) : 'inherit',
   };
 
   return (
@@ -126,16 +148,7 @@ const MembersFilterDropdown = () => {
       <Button
         icon={<CaretDownFilled />}
         iconPosition="end"
-        style={{
-          backgroundColor:
-            selectedCount > 0
-              ? themeMode === 'dark'
-                ? '#003a5c'
-                : colors.paleBlue
-              : colors.transparent,
-
-          color: selectedCount > 0 ? (themeMode === 'dark' ? 'white' : colors.darkGray) : 'inherit',
-        }}
+        style={buttonStyle}
       >
         <Space>
           {t('membersText')}

--- a/src/pages/projects/projectView/taskList/taskListFilters/SearchDropdown.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/SearchDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import debounce from 'lodash/debounce';
+import { useSearchParams } from 'react-router-dom';
 
 import { InputRef } from 'antd/es/input';
 import Button from 'antd/es/button';
@@ -14,19 +15,30 @@ import Dropdown from 'antd/es/dropdown';
 import { setSearch } from '@/features/tasks/tasks.slice';
 import { SearchOutlined } from '@ant-design/icons';
 
+import { setBoardSearch } from '@/features/board/board-slice';
+
+
 const SearchDropdown = () => {
   const { t } = useTranslation('task-list-filters');
   const dispatch = useDispatch();
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const searchInputRef = useRef<InputRef>(null);
+  const [searchParams] = useSearchParams();
+
+  const tab = searchParams.get('tab');
+  const projectView = tab === 'tasks-list' ? 'list' : 'kanban';
 
   // Debounced search dispatch
   const debouncedSearch = useCallback(
     debounce((value: string) => {
-      dispatch(setSearch(value));
+      if (projectView === 'list') {
+        dispatch(setSearch(value));
+      } else {
+        dispatch(setBoardSearch(value));
+      }
     }, 300),
-    [dispatch]
+    [dispatch, projectView]
   );
 
   const handleSearch = useCallback(() => {
@@ -35,8 +47,12 @@ const SearchDropdown = () => {
 
   const handleReset = useCallback(() => {
     setSearchValue('');
-    dispatch(setSearch(''));
-  }, [dispatch]);
+    if (projectView === 'list') {
+      dispatch(setSearch(''));
+    } else {
+      dispatch(setBoardSearch(''));
+    }
+  }, [dispatch, projectView]);
 
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);

--- a/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
+++ b/src/pages/projects/projectView/taskList/taskListFilters/TaskListFilters.tsx
@@ -15,7 +15,7 @@ import {
   toggleArchived,
 } from '@/features/tasks/tasks.slice';
 import { getTeamMembers } from '@/features/team-members/team-members.slice';
-import { fetchTaskGroups } from '@/features/board/board-slice';
+import { fetchBoardTaskGroups } from '@/features/board/board-slice';
 
 const SearchDropdown = React.lazy(() => import('./SearchDropdown'));
 const SortFilterDropdown = React.lazy(() => import('./SortFilterDropdown'));

--- a/src/pages/projects/projectView/taskList/taskListTable/TaskListTable.tsx
+++ b/src/pages/projects/projectView/taskList/taskListTable/TaskListTable.tsx
@@ -431,10 +431,12 @@ const TaskListTable: React.FC<TaskListTableProps> = ({ taskList, tableId, active
                     : '#fff',
               }}
             >
-              <Flex gap={8} align="center">
-                <div {...attributes} {...listeners}>
-                  <HolderOutlined style={{ cursor: 'grab' }} />
-                </div>
+              <Flex gap={8} align="center" justify={isSubtask ? 'flex-end' : 'flex-start'}>
+                {!isSubtask && (
+                  <div {...attributes} {...listeners}>
+                    <HolderOutlined style={{ cursor: 'grab' }} />
+                  </div>
+                )}
                 <Checkbox
                   checked={selectedTaskIdsList.includes(task.id || '')}
                   onChange={() => toggleRowSelection(task)}

--- a/src/services/task-list/taskList.service.ts
+++ b/src/services/task-list/taskList.service.ts
@@ -1,4 +1,4 @@
-import { getCurrentGroup } from '@/features/board/board-slice';
+import { getCurrentGroupBoard } from '@/features/board/board-slice';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
 import { IGroupByOption } from '@/types/tasks/taskList.types';
 import { NavigateFunction } from 'react-router-dom';
@@ -26,7 +26,7 @@ export const createTaskListService = (navigate: NavigateFunction): TaskListServi
 };
 
 export const getGroupIdByGroupedColumn = (task: IProjectTask) => {
-  const groupBy = getCurrentGroup().value;
+  const groupBy = getCurrentGroupBoard().value;
   if (groupBy === GROUP_BY_STATUS_VALUE)
     return task.status as string;
 


### PR DESCRIPTION
- Implement consistent state handling for board and task list views
- Add support for switching between list and kanban views using URL tab parameter
- Update filter dropdowns to work with both board and task list states
- Rename and refactor slice actions for board-specific operations
- Improve type consistency and state access across components