### PR TITLE
refactor: Comment out kanban-specific group handling in GroupByFilter…

### DIFF
--- a/src/components/project-task-filters/filter-dropdowns/group-by-filter-dropdown.tsx
+++ b/src/components/project-task-filters/filter-dropdowns/group-by-filter-dropdown.tsx
@@ -36,9 +36,9 @@ const GroupByFilterDropdown = () => {
       { key: IGroupBy.PHASE, label: project?.phase_label || t('phaseText') },
     ];
 
-    if (projectView === 'kanban') {
-      return [...baseItems, { key: IGroupBy.MEMBERS, label: t('memberText') }];
-    }
+    // if (projectView === 'kanban') {
+    //   return [...baseItems, { key: IGroupBy.MEMBERS, label: t('memberText') }];
+    // }
 
     return baseItems;
   }, [t, project?.phase_label, projectView]);


### PR DESCRIPTION
…Dropdown

- Removed the conditional return for members grouping in kanban view to simplify the dropdown logic.
- This change prepares the component for potential future enhancements without affecting current functionality.