### PR TITLE
feat: Add alert for incomplete task dependencies in task status change

### DIFF
--- a/src/pages/projects/projectView/taskList/taskListTable/task-group-wrapper/task-group-wrapper.tsx
+++ b/src/pages/projects/projectView/taskList/taskListTable/task-group-wrapper/task-group-wrapper.tsx
@@ -63,6 +63,7 @@ import { useMixpanelTracking } from '@/hooks/useMixpanelTracking';
 import { evt_project_task_list_drag_and_move } from '@/shared/worklenz-analytics-events';
 import { ALPHA_CHANNEL } from '@/shared/constants';
 import { IProjectTask } from '@/types/project/projectTasksViewModel.types';
+import alertService from '@/services/alerts/alertService';
 
 interface TaskGroupWrapperProps {
   taskGroups: ITaskListGroup[];
@@ -163,6 +164,12 @@ const TaskGroupWrapper = ({ taskGroups, groupBy }: TaskGroupWrapperProps) => {
     if (!socket) return;
 
     const handleTaskStatusChange = (response: ITaskListStatusChangeResponse) => {
+      console.log('response', response);
+      if (response.completed_deps === false) {
+        alertService.error('Task is not completed', 'Please complete the task dependencies before proceeding');
+        return;
+      }
+
       dispatch(updateTaskStatus(response));
       dispatch(setTaskStatus(response));
       dispatch(deselectAll());

--- a/src/types/tasks/task-list-status.types.ts
+++ b/src/types/tasks/task-list-status.types.ts
@@ -12,4 +12,5 @@ export interface ITaskListStatusChangeResponse {
     is_doing: boolean;
     is_done: boolean;
   };
+  completed_deps?: boolean;
 }


### PR DESCRIPTION
- Integrated alertService to notify users when task dependencies are not completed before proceeding with status changes.
- Updated ITaskListStatusChangeResponse interface to include completed_deps property for better status handling.