### PR TITLE
fix: Add singular localization for days left in English, Spanish, and…

### DIFF
--- a/public/locales/en/reporting-projects.json
+++ b/public/locales/en/reporting-projects.json
@@ -38,6 +38,7 @@
   "continuousText": "Continuous",
 
   "daysLeftText": "days left",
+  "dayLeftText": "day left",
   "daysOverdueText": "days overdue",
 
   "notSetText": "NotSet",

--- a/public/locales/es/reporting-projects.json
+++ b/public/locales/es/reporting-projects.json
@@ -38,6 +38,7 @@
   "continuousText": "Continuo",
 
   "daysLeftText": "días restantes",
+  "dayLeftText": "día restante",
   "daysOverdueText": "días de retraso",
 
   "notSetText": "No Establecido",

--- a/public/locales/pt/reporting-projects.json
+++ b/public/locales/pt/reporting-projects.json
@@ -38,6 +38,7 @@
   "continuousText": "Contínuo",
 
   "daysLeftText": "dias restantes",
+  "dayLeftText": "dia restante",
   "daysOverdueText": "dias atrasados",
 
   "notSetText": "Não Definido",

--- a/src/pages/reporting/projects-reports/projects-reports-table/table-cells/project-days-left-and-overdue-cell/project-days-left-and-overdue-cell.tsx
+++ b/src/pages/reporting/projects-reports/projects-reports-table/table-cells/project-days-left-and-overdue-cell/project-days-left-and-overdue-cell.tsx
@@ -32,7 +32,7 @@ const ProjectDaysLeftAndOverdueCell = ({
                 </Typography.Text>
               ) : (
                 <Typography.Text style={{ cursor: 'pointer', color: colors.limeGreen }}>
-                  {daysLeft} {t('daysLeftText')}
+                  {daysLeft} {daysLeft === 1 ? t('dayLeftText') : t('daysLeftText')}
                 </Typography.Text>
               )}
             </>


### PR DESCRIPTION
… Portuguese

- Added "day left" localization for singular cases in English, Spanish, and Portuguese localization files.
- Updated ProjectDaysLeftAndOverdueCell to utilize the new singular localization for improved accuracy in display.