### PR TITLE
feat: Update custom column addition to ensure visibility by default

### DIFF
--- a/src/features/tasks/tasks.slice.ts
+++ b/src/features/tasks/tasks.slice.ts
@@ -875,11 +875,11 @@ const taskSlice = createSlice({
     },
 
     addCustomColumn: (state, action: PayloadAction<ITaskListColumn>) => {
-      console.log('action.payload', action.payload);
       state.customColumns.push(action.payload);
       // Also add to columns array to maintain visibility
       state.columns.push({
         ...action.payload,
+        pinned: true // New columns are visible by default
       });
     },
 


### PR DESCRIPTION
- Modified addCustomColumn in tasks.slice.ts to set new columns as pinned, ensuring they are visible by default.
- Removed console log statement for cleaner code.