### PR TITLE
Update addMoreSeats method to use POST request for seat purchases

### DIFF
--- a/src/api/admin-center/admin-center.api.service.ts
+++ b/src/api/admin-center/admin-center.api.service.ts
@@ -233,7 +233,7 @@ export const adminCenterApiService = {
   },
 
   async addMoreSeats(totalSeats: number): Promise<IServerResponse<any>> {
-    const response = await apiClient.get<IServerResponse<any>>(`${rootUrl}/billing/add-more-seats?totalSeats=${totalSeats}`);
+    const response = await apiClient.post<IServerResponse<any>>(`${rootUrl}/billing/purchase-more-seats`, {seatCount: totalSeats});
     return response.data;
   },
 


### PR DESCRIPTION
- Changed the `addMoreSeats` method to utilize a POST request instead of GET for adding seats, aligning with API specifications.
- Updated the request payload to include `seatCount` for better clarity in the API call.